### PR TITLE
Update init.py

### DIFF
--- a/init.py
+++ b/init.py
@@ -181,7 +181,7 @@ class GizmoPathManager(object):
                 if defaultSubMenu:
                     subMenu = toolbar.findItem(defaultSubMenu)
                 else:
-                    subMenu = toolbar.addMenu(folder)
+                    subMenu = toolbar.addMenu(folder, icon=folder + ".png")
             self._recursiveAddGizmoMenuItems(subMenu, data)
 
 


### PR DESCRIPTION
Added icon loading to folders that do not match predefined Nuke categories. Icon should match the new 'folder' name and be a png file.  Icon should be placed in /plugins/icons

If no Icon file is found the default plugin icon is used.

Ex: /Gizmos/<new_folder>
  : /plugins/icons/new_folder.png
